### PR TITLE
Added spacing between icons and text where missing

### DIFF
--- a/src/assets/scripts/embed.njk
+++ b/src/assets/scripts/embed.njk
@@ -152,12 +152,12 @@ class WebringBanner extends HTMLElement {
                 href="${this.url}/prev" 
                 class="webring-banner__link webring-banner__link--prev" 
                 aria-label="Go to previous site"
-              >⬅️Previous</a>
+              >⬅️ Previous</a>
               <a
                 href="${this.url}/random"
                 class="webring-banner__link webring-banner__link--random" 
                 aria-label="Go to a random site"
-              >😎Random</a>
+              >😎 Random</a>
               <a
                 href="${this.url}/next"
                 class="webring-banner__link webring-banner__link--next"


### PR DESCRIPTION
This is obviously personal preference, but for consistency I aligned the embed `Previous` and the `Random` link to the `Next` one, adding a space in between the text and the icon. 